### PR TITLE
fix: use provided env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You need to replace $GOPATH/bin with the actual location of the binary on your s
 provider_installation {
 
   dev_overrides {
-      "registry.terraform.io/hashicorp/infomaniak" = "$GOPATH/bin"
+      "registry.terraform.io/infomaniak/infomaniak" = "$GOPATH/bin"
   }
 
   # For all other providers, install them directly from their origin provider

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -124,16 +124,16 @@ func (p *IkProvider) Configure(ctx context.Context, req provider.ConfigureReques
 	host := os.Getenv(INFOMANIAK_HOST)
 	token := os.Getenv(INFOMANIAK_TOKEN)
 
-	if host == "" && !data.Host.IsNull() {
-		host = data.Host.ValueString()
+	if host == "" {
+		if !data.Host.IsNull() {
+			host = data.Host.ValueString()
+		} else {
+			host = DefaultHost
+		}
 	}
 
 	if token == "" && !data.Token.IsNull() {
 		token = data.Token.ValueString()
-	}
-
-	if host == "" {
-		host = DefaultHost
 	}
 
 	data.Host = types.StringValue(host)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -134,8 +134,10 @@ func (p *IkProvider) Configure(ctx context.Context, req provider.ConfigureReques
 
 	if host == "" {
 		host = DefaultHost
-		data.Host = types.StringValue(host)
 	}
+
+	data.Host = types.StringValue(host)
+	data.Token = types.StringValue(token)
 
 	if token == "" {
 		resp.Diagnostics.AddAttributeError(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -124,11 +124,11 @@ func (p *IkProvider) Configure(ctx context.Context, req provider.ConfigureReques
 	host := os.Getenv(INFOMANIAK_HOST)
 	token := os.Getenv(INFOMANIAK_TOKEN)
 
-	if !data.Host.IsNull() {
+	if host == "" && !data.Host.IsNull() {
 		host = data.Host.ValueString()
 	}
 
-	if !data.Token.IsNull() {
+	if token == "" && !data.Token.IsNull() {
 		token = data.Token.ValueString()
 	}
 


### PR DESCRIPTION
# Issue

When using the provider and using env variables, it would not load them properly and the provider would not be able to work correctly.

This PR also fixes the incorrect README reference that comes from the scaffolding process.
