### PR TITLE
feat(kaas): properly await instance pool

### DIFF
--- a/internal/apis/kaas/implementation/client.go
+++ b/internal/apis/kaas/implementation/client.go
@@ -187,6 +187,11 @@ func (client *Client) GetInstancePool(publicCloudId int, publicCloudProjectId in
 		return nil, result.Error
 	}
 
+	// Default Max = Min
+	if result.Data.MaxInstances == 0 {
+		result.Data.MaxInstances = result.Data.MinInstances
+	}
+
 	return result.Data, nil
 }
 

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -37,8 +37,11 @@ type InstancePool struct {
 	FlavorName       string `json:"flavor,omitempty"`
 	AvailabilityZone string `json:"availability_zone,omitempty"`
 	MinInstances     int32  `json:"minimum_instances,omitempty"`
-	// MaxInstances     int32  `json:"maximum_instances,omitempty"`
-	Status string `json:"status,omitempty"`
+	MaxInstances     int32  `json:"maximum_instances,omitempty"`
+	Status           string `json:"status,omitempty"`
+
+	TargetInstances    int32 `json:"target_instances,omitempty"`
+	AvailableInstances int32 `json:"available_instances,omitempty"`
 }
 
 func (instancePool *InstancePool) Key() string {


### PR DESCRIPTION
We now wait for several conditions to be okay before saying the the instance pool is okay : 

- Must be in the Active state
- Must have the same parameters as expected (`remote.min == expected.min`)
- Must be scaled properly (`remote.target == remote.available`)
- Target must be in bound of autoscaling, in the current state, the only acceptable value for `remote.target` is `expected.min`