### PR TITLE
fix(kaas): prevent further regressions and fix kubeconfig call

### DIFF
--- a/internal/apis/dbaas/models.go
+++ b/internal/apis/dbaas/models.go
@@ -43,5 +43,5 @@ func (dbaas *DBaaS) Key() string {
 
 type DBaaSProject struct {
 	PublicCloudId int `json:"public_cloud_id,omitempty"`
-	ProjectId     int `json:"project_cloud_project_id,omitempty"`
+	ProjectId     int `json:"id,omitempty"`
 }

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -26,7 +26,7 @@ func (kaas *Kaas) Key() string {
 
 type KaasProject struct {
 	PublicCloudId int `json:"public_cloud_id,omitempty"`
-	ProjectId     int `json:"project_cloud_project_id,omitempty"`
+	ProjectId     int `json:"id,omitempty"`
 }
 
 type InstancePool struct {


### PR DESCRIPTION
## Issue

When the front-facing API was updated, a breaking change was introduced that modified the response to the `GetKaas` call.
Specifically, the object containing the project's information changed : 

From :
```json
"project": {
   "project_cloud_project_id": 16297,
   "public_cloud_id": 9602,
   "name": "kaas-0",
   "open_stack_name": "PCP-WHRJGLU"
}
```

To :
```json
"project": {
   "id": 16297,
   "public_cloud_id": 9602,
   "name": "kaas-0",
   "open_stack_name": "PCP-WHRJGLU"
}
```

## Fixes

- [x] Fix the models that changed on the API side.
- [x] Do not update the state if the Kubeconfig cannot be GET from the API.
- [x] Call the API endpoint using known values (from state or inputs) instead of relying on the `GetKaas` call.