### PR TITLE
feat(kaas): edit apiserver params

### DIFF
--- a/examples/kaas/main.tf
+++ b/examples/kaas/main.tf
@@ -21,6 +21,24 @@ resource "infomaniak_kaas" "create_kluster" {
   pack_name          = var.cluster_type
   kubernetes_version = var.cluster_version
   region             = var.cluster_region
+
+  apiserver = {
+    params = {
+      "--oidc-groups-claim" = "custom-set-param"
+    }
+    audit = {
+      webhook_config = file(var.audit_logs_webhook_filename)
+      policy = null
+    }
+    oidc = {
+      issuer_url      = var.issuer_url
+      client_id       = var.client_id
+      username_claim  = var.username_claim
+      username_prefix = var.username_prefix
+      signing_algs    = var.signing_algs
+      ca              = file(var.oidc_ca_filename)
+    }
+  }
 }
 
 resource "infomaniak_kaas_instance_pool" "create_instance_pool_1" {

--- a/examples/kaas/variables.tf
+++ b/examples/kaas/variables.tf
@@ -58,3 +58,46 @@ variable "pool_labels" {
     "node-role.kubernetes.io/worker" = "high"
   }
 }
+
+variable "issuer_url" {
+  description = "OIDC issuer url"
+  type        = string
+  default     = "https://issuer.url.example.com"
+}
+
+variable "client_id" {
+  description = "OIDC client id"
+  type        = string
+  default     = "kube-login"
+}
+
+variable "username_claim" {
+  description = "OIDC username claim"
+  type        = string
+  default     = "email"
+}
+
+variable "username_prefix" {
+  description = "OIDC username prefix"
+  type        = string
+  default     = "oidc:"
+}
+
+variable "signing_algs" {
+  description = "OIDC effective signing algorithm"
+  type        = string
+  default     = "RS256"
+}
+
+
+variable "audit_logs_webhook_filename" {
+  description = "Audit logs webhook yaml filename"
+  type        = string
+  default     = "./webhook.yaml"
+}
+
+variable "oidc_ca_filename" {
+  description = "oidc CA certificate local file path"
+  type        = string
+  default     = "./oidc_ca.crt"
+}

--- a/internal/apis/kaas/implementation/client.go
+++ b/internal/apis/kaas/implementation/client.go
@@ -263,27 +263,6 @@ func (client *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId
 	return result.Data, nil
 }
 
-func (client *Client) CreateApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
-	var result helpers.NormalizedApiResponse[bool]
-	resp, err := client.resty.R().
-		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
-		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
-		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
-		SetBody(input).
-		SetResult(&result).
-		SetError(&result).
-		Post(EndpointApiserver)
-	if err != nil {
-		return false, err
-	}
-
-	if resp.IsError() {
-		return false, result.Error
-	}
-
-	return result.Data, nil
-}
-
 func (client *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 	resp, err := client.resty.R().

--- a/internal/apis/kaas/implementation/client.go
+++ b/internal/apis/kaas/implementation/client.go
@@ -262,3 +262,67 @@ func (client *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId
 
 	return result.Data, nil
 }
+
+func (client *Client) CreateApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+	var result helpers.NormalizedApiResponse[bool]
+	resp, err := client.resty.R().
+		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
+		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
+		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
+		SetBody(input).
+		SetResult(&result).
+		SetError(&result).
+		Post(EndpointApiserver)
+	if err != nil {
+		return false, err
+	}
+
+	if resp.IsError() {
+		return false, result.Error
+	}
+
+	return result.Data, nil
+}
+
+func (client *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+	var result helpers.NormalizedApiResponse[bool]
+	resp, err := client.resty.R().
+		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
+		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
+		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
+		SetBody(input).
+		SetResult(&result).
+		SetError(&result).
+		Patch(EndpointApiserver)
+
+	if err != nil {
+		return false, err
+	}
+
+	if resp.IsError() {
+		return false, result.Error
+	}
+
+	return result.Data, nil
+}
+
+func (client *Client) GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*kaas.Apiserver, error) {
+
+	var result helpers.NormalizedApiResponse[*kaas.Apiserver]
+	resp, err := client.resty.R().
+		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
+		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
+		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
+		SetResult(&result).
+		SetError(&result).
+		Get(EndpointApiserver)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.IsError() {
+		return nil, result.Error
+	}
+
+	return result.Data, nil
+}

--- a/internal/apis/kaas/implementation/endpoints.go
+++ b/internal/apis/kaas/implementation/endpoints.go
@@ -10,4 +10,6 @@ var (
 
 	EndpointInstancePools = "/1/public_clouds/{public_cloud_id}/projects/{public_cloud_project_id}/kaas/{kaas_id}/instance_pools"
 	EndpointInstancePool  = "/1/public_clouds/{public_cloud_id}/projects/{public_cloud_project_id}/kaas/{kaas_id}/instance_pools/{kaas_instance_pool_id}"
+
+	EndpointApiserver = "/1/public_clouds/{public_cloud_id}/projects/{public_cloud_project_id}/kaas/{kaas_id}/apiserver"
 )

--- a/internal/apis/kaas/mock/client.go
+++ b/internal/apis/kaas/mock/client.go
@@ -275,3 +275,13 @@ func (c *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId int,
 
 	return true, removeFromCache(&obj)
 }
+
+func (c *Client) GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*kaas.Apiserver, error) {
+	return nil, nil
+}
+func (c *Client) CreateApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+	return true, nil
+}
+func (c *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+	return true, nil
+}

--- a/internal/apis/kaas/mock/client.go
+++ b/internal/apis/kaas/mock/client.go
@@ -279,9 +279,6 @@ func (c *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId int,
 func (c *Client) GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*kaas.Apiserver, error) {
 	return nil, nil
 }
-func (c *Client) CreateApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
-	return true, nil
-}
 func (c *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
 	return true, nil
 }

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -13,7 +13,7 @@ type KaasPack struct {
 }
 
 type Apiserver struct {
-	Params                     *ApiServerParams   `json:"apiserver_params,omitempty"`
+	Params                     *ApiServerParams   `json:"apiserver_params"`
 	NonSpecificApiServerParams map[string]string `json:"-"`
 
 	OidcCa          *string `json:"oidc_ca"`

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -13,7 +13,7 @@ type KaasPack struct {
 }
 
 type Apiserver struct {
-	Params                     ApiServerParams   `json:"apiserver_params,omitempty"`
+	Params                     *ApiServerParams   `json:"apiserver_params,omitempty"`
 	NonSpecificApiServerParams map[string]string `json:"-"`
 
 	OidcCa          *string `json:"oidc_ca"`

--- a/internal/apis/kaas/spec.go
+++ b/internal/apis/kaas/spec.go
@@ -15,4 +15,8 @@ type Api interface {
 	CreateInstancePool(publicCloudId int, publicCloudProjectId int, input *InstancePool) (int, error)
 	UpdateInstancePool(publicCloudId int, publicCloudProjectId int, input *InstancePool) (bool, error)
 	DeleteInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (bool, error)
+
+	GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*Apiserver, error)
+	CreateApiserverParams(input *Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error)
+	PatchApiserverParams(input *Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error)
 }

--- a/internal/apis/kaas/spec.go
+++ b/internal/apis/kaas/spec.go
@@ -17,6 +17,5 @@ type Api interface {
 	DeleteInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (bool, error)
 
 	GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*Apiserver, error)
-	CreateApiserverParams(input *Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error)
 	PatchApiserverParams(input *Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error)
 }

--- a/internal/services/kaas/kaas_data_source.go
+++ b/internal/services/kaas/kaas_data_source.go
@@ -218,19 +218,7 @@ func (d *kaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	if apiserverParams != nil {
-		data.SetDefaultValues(ctx)
-		data.Apiserver.Audit.Policy = types.StringPointerValue(apiserverParams.AuditLogPolicy)
-		data.Apiserver.Audit.WebhookConfig = types.StringPointerValue(apiserverParams.AuditLogWebhook)
-		data.Apiserver.Oidc.Ca = types.StringPointerValue(apiserverParams.OidcCa)
-		if apiserverParams.Params != nil {
-			data.Apiserver.Oidc.ClientId = types.StringValue(apiserverParams.Params.ClientId)
-			data.Apiserver.Oidc.IssuerUrl = types.StringValue(apiserverParams.Params.IssuerUrl)
-			data.Apiserver.Oidc.UsernameClaim = types.StringValue(apiserverParams.Params.UsernameClaim)
-			data.Apiserver.Oidc.UsernamePrefix = types.StringValue(apiserverParams.Params.UsernamePrefix)
-			data.Apiserver.Oidc.SigningAlgs = types.StringValue(apiserverParams.Params.SigningAlgs)
-			data.Apiserver.Oidc.GroupsClaim = types.StringValue(apiserverParams.Params.GroupsClaim)
-			data.Apiserver.Oidc.GroupsPrefix = types.StringValue(apiserverParams.Params.GroupsPrefix)
-		}
+		data.fillApiserverState(ctx, apiserverParams)
 	}
 
 	// Set state

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -16,8 +16,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -40,11 +43,34 @@ type KaasModel struct {
 	PublicCloudProjectId types.Int64 `tfsdk:"public_cloud_project_id"`
 	Id                   types.Int64 `tfsdk:"id"`
 
-	Name              types.String `tfsdk:"name"`
-	PackName          types.String `tfsdk:"pack_name"`
-	Region            types.String `tfsdk:"region"`
-	Kubeconfig        types.String `tfsdk:"kubeconfig"`
-	KubernetesVersion types.String `tfsdk:"kubernetes_version"`
+	Name              types.String    `tfsdk:"name"`
+	PackName          types.String    `tfsdk:"pack_name"`
+	Region            types.String    `tfsdk:"region"`
+	Kubeconfig        types.String    `tfsdk:"kubeconfig"`
+	KubernetesVersion types.String    `tfsdk:"kubernetes_version"`
+	Apiserver         *ApiserverModel `tfsdk:"apiserver"`
+}
+
+type ApiserverModel struct {
+	Params types.Map  `tfsdk:"params"`
+	Oidc   *OidcModel `tfsdk:"oidc"`
+	Audit  *Audit     `tfsdk:"audit"`
+}
+
+type OidcModel struct {
+	IssuerUrl      types.String `tfsdk:"issuer_url"`
+	ClientId       types.String `tfsdk:"client_id"`
+	UsernameClaim  types.String `tfsdk:"username_claim"`
+	UsernamePrefix types.String `tfsdk:"username_prefix"`
+	SigningAlgs    types.String `tfsdk:"signing_algs"`
+	GroupsClaim    types.String `tfsdk:"groups_claim"`
+	GroupsPrefix   types.String `tfsdk:"groups_prefix"`
+	Ca             types.String `tfsdk:"ca"`
+}
+
+type Audit struct {
+	WebhookConfig types.String `tfsdk:"webhook_config"`
+	Policy        types.String `tfsdk:"policy"`
 }
 
 func (r *kaasResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -137,6 +163,106 @@ func (r *kaasResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Description:         "The kubeconfig generated to access to KaaS project",
 				MarkdownDescription: "The kubeconfig generated to access to KaaS project",
 			},
+			"apiserver": schema.SingleNestedAttribute{
+				MarkdownDescription: "Kubernetes Apiserver editable params",
+				Attributes: map[string]schema.Attribute{
+					"params": schema.MapAttribute{
+						Optional:            true,
+						ElementType:         types.StringType,
+						MarkdownDescription: "Map of Kubernetes Apiserver params in case the terraform provider does not already abstracts them",
+						PlanModifiers: []planmodifier.Map{
+							mapplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"audit": schema.SingleNestedAttribute{
+						MarkdownDescription: "Kubernetes audit logs specification files",
+						Optional:            true,
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
+						Attributes: map[string]schema.Attribute{
+							"webhook_config": schema.StringAttribute{
+								MarkdownDescription: "YAML manifest for audit webhook config",
+								Optional:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+							"policy": schema.StringAttribute{
+								MarkdownDescription: "YAML manifest for audit policy",
+								Optional:            true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+							},
+						},
+					},
+					"oidc": schema.SingleNestedAttribute{
+						MarkdownDescription: "OIDC specific Apiserver params",
+						Optional:            true,
+						Attributes: map[string]schema.Attribute{
+							"ca": schema.StringAttribute{
+								Optional:  true,
+								Sensitive: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC Ca Certificate",
+							},
+							"groups_claim": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC groups claim",
+							},
+							"groups_prefix": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC groups prefix",
+							},
+							"issuer_url": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC issuer URL",
+							},
+							"client_id": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC client identifier",
+							},
+							"username_claim": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC username claim",
+							},
+							"username_prefix": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC username prefix",
+							},
+							"signing_algs": schema.StringAttribute{
+								Optional: true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
+								MarkdownDescription: "OIDC signing algorithm. Kubernetes will default it to RS256",
+							},
+						},
+					},
+				},
+				Optional: true,
+			},
 		},
 		MarkdownDescription: "The kaas resource allows the user to manage a kaas project",
 	}
@@ -147,7 +273,6 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -207,6 +332,32 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	data.fill(kaasObject)
 
+	oidcInput := &kaas.Apiserver{
+		OidcCa:          data.Apiserver.Oidc.Ca.ValueStringPointer(),
+		AuditLogWebhook: data.Apiserver.Audit.WebhookConfig.ValueStringPointer(),
+		AuditLogPolicy:  data.Apiserver.Audit.Policy.ValueStringPointer(),
+		Params: kaas.ApiServerParams{
+			IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
+			ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
+			UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
+			UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
+			SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
+			GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
+			GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
+		},
+		NonSpecificApiServerParams: r.getApiserverParamsValues(data),
+	}
+	created, err := r.client.Kaas.CreateApiserverParams(oidcInput, input.Project.PublicCloudId, input.Project.ProjectId, kaasId)
+	if !created || err != nil {
+		resp.Diagnostics.AddError(
+			"Error when creating Oidc",
+			err.Error(),
+		)
+		return
+	}
+
+	data.fill(kaasObject)
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -228,6 +379,19 @@ func (r *kaasResource) waitUntilActive(ctx context.Context, kaas *kaas.Kaas, id 
 
 		time.Sleep(5 * time.Second)
 	}
+}
+
+func (r *kaasResource) getApiserverParamsValues(data KaasModel) map[string]string {
+	params := make(map[string]string)
+	if !data.Apiserver.Params.IsNull() && !data.Apiserver.Params.IsUnknown() {
+		for key, val := range data.Apiserver.Params.Elements() {
+			if strVal, ok := val.(types.String); ok && !strVal.IsNull() && !strVal.IsUnknown() {
+				params[key] = strVal.ValueString()
+			}
+		}
+	}
+
+	return params
 }
 
 func (r *kaasResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -263,6 +427,32 @@ func (r *kaasResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		)
 	} else {
 		state.Kubeconfig = types.StringValue(kubeconfig)
+	}
+
+	apiserverParams, err := r.client.Kaas.GetApiserverParams(kaasObject.Project.PublicCloudId, kaasObject.Project.ProjectId, kaasObject.Id)
+	if err != nil {
+		resp.Diagnostics.AddWarning(
+			"Could not get Oidc",
+			err.Error(),
+		)
+	}
+	if apiserverParams != nil {
+		if state.Apiserver.Audit == nil {
+			state.Apiserver.Audit = &Audit{}
+		}
+		if state.Apiserver.Oidc == nil {
+			state.Apiserver.Oidc = &OidcModel{}
+		}
+		state.Apiserver.Audit.Policy = types.StringPointerValue(apiserverParams.AuditLogPolicy)
+		state.Apiserver.Audit.WebhookConfig = types.StringPointerValue(apiserverParams.AuditLogWebhook)
+		state.Apiserver.Oidc.Ca = types.StringPointerValue(apiserverParams.OidcCa)
+		state.Apiserver.Oidc.ClientId = types.StringValue(apiserverParams.Params.ClientId)
+		state.Apiserver.Oidc.IssuerUrl = types.StringValue(apiserverParams.Params.IssuerUrl)
+		state.Apiserver.Oidc.UsernameClaim = types.StringValue(apiserverParams.Params.UsernameClaim)
+		state.Apiserver.Oidc.UsernamePrefix = types.StringValue(apiserverParams.Params.UsernamePrefix)
+		state.Apiserver.Oidc.SigningAlgs = types.StringValue(apiserverParams.Params.SigningAlgs)
+		state.Apiserver.Oidc.GroupsClaim = types.StringValue(apiserverParams.Params.GroupsClaim)
+		state.Apiserver.Oidc.GroupsPrefix = types.StringValue(apiserverParams.Params.GroupsPrefix)
 	}
 
 	state.fill(kaasObject)
@@ -339,6 +529,30 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	data.fill(kaasObject)
+
+	oidcInput := &kaas.Apiserver{
+		OidcCa:          data.Apiserver.Oidc.Ca.ValueStringPointer(),
+		AuditLogWebhook: data.Apiserver.Audit.WebhookConfig.ValueStringPointer(),
+		AuditLogPolicy:  data.Apiserver.Audit.Policy.ValueStringPointer(),
+		Params: kaas.ApiServerParams{
+			IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
+			ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
+			UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
+			UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
+			SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
+			GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
+			GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
+		},
+		NonSpecificApiServerParams: r.getApiserverParamsValues(data),
+	}
+	patched, err := r.client.Kaas.PatchApiserverParams(oidcInput, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
+	if !patched || err != nil {
+		resp.Diagnostics.AddError(
+			"Error when creating Oidc",
+			err.Error(),
+		)
+		return
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -350,25 +350,7 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	if data.Apiserver != nil {
-		apiserverParamsInput := &kaas.Apiserver{
-			NonSpecificApiServerParams: r.getApiserverParamsValues(data),
-		}
-		if data.Apiserver.Audit != nil {
-			apiserverParamsInput.AuditLogPolicy = data.Apiserver.Audit.Policy.ValueStringPointer()
-			apiserverParamsInput.AuditLogWebhook = data.Apiserver.Audit.WebhookConfig.ValueStringPointer()
-		}
-		if data.Apiserver.Oidc != nil {
-			apiserverParamsInput.OidcCa = data.Apiserver.Oidc.Ca.ValueStringPointer()
-			apiserverParamsInput.Params = &kaas.ApiServerParams{
-				IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
-				ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
-				UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
-				UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
-				SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
-				GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
-				GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
-			}
-		}
+		apiserverParamsInput := r.buildApiserverParamsInput(data)
 		created, err := r.client.Kaas.PatchApiserverParams(apiserverParamsInput, input.Project.PublicCloudId, input.Project.ProjectId, kaasId)
 		if !created || err != nil {
 			resp.Diagnostics.AddError(
@@ -550,25 +532,7 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	data.fill(kaasObject)
 
 	if data.Apiserver != nil {
-		apiserverParamsInput := &kaas.Apiserver{
-			NonSpecificApiServerParams: r.getApiserverParamsValues(data),
-		}
-		if data.Apiserver.Audit != nil {
-			apiserverParamsInput.AuditLogPolicy = data.Apiserver.Audit.Policy.ValueStringPointer()
-			apiserverParamsInput.AuditLogWebhook = data.Apiserver.Audit.WebhookConfig.ValueStringPointer()
-		}
-		if data.Apiserver.Oidc != nil {
-			apiserverParamsInput.OidcCa = data.Apiserver.Oidc.Ca.ValueStringPointer()
-			apiserverParamsInput.Params = &kaas.ApiServerParams{
-				IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
-				ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
-				UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
-				UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
-				SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
-				GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
-				GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
-			}
-		}
+		apiserverParamsInput := r.buildApiserverParamsInput(data)
 		patched, err := r.client.Kaas.PatchApiserverParams(apiserverParamsInput, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
 		if !patched || err != nil {
 			resp.Diagnostics.AddError(
@@ -580,6 +544,29 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *kaasResource) buildApiserverParamsInput(data KaasModel) *kaas.Apiserver {
+	apiserverParamsInput := &kaas.Apiserver{
+		NonSpecificApiServerParams: r.getApiserverParamsValues(data),
+	}
+	if data.Apiserver.Audit != nil {
+		apiserverParamsInput.AuditLogPolicy = data.Apiserver.Audit.Policy.ValueStringPointer()
+		apiserverParamsInput.AuditLogWebhook = data.Apiserver.Audit.WebhookConfig.ValueStringPointer()
+	}
+	if data.Apiserver.Oidc != nil {
+		apiserverParamsInput.OidcCa = data.Apiserver.Oidc.Ca.ValueStringPointer()
+		apiserverParamsInput.Params = &kaas.ApiServerParams{
+			IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
+			ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
+			UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
+			UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
+			SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
+			GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
+			GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
+		}
+	}
+	return apiserverParamsInput
 }
 
 func (r *kaasResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {


### PR DESCRIPTION
This PR addresses an issue causing a crash when attempting to use an older project without any API server parameters set. It also re-add the possibility to edit apiserver params

(EDITED:yewolf) : This PR comes from #22 after the revert that occured in #27