### PR TITLE
fix(kaas): optional Apiserver params

### DIFF
--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -13,7 +13,7 @@ type KaasPack struct {
 }
 
 type Apiserver struct {
-	Params                     *ApiServerParams   `json:"apiserver_params"`
+	Params                     *ApiServerParams  `json:"apiserver_params"`
 	NonSpecificApiServerParams map[string]string `json:"-"`
 
 	OidcCa          *string `json:"oidc_ca"`
@@ -45,13 +45,13 @@ func (a *Apiserver) MarshalJSON() ([]byte, error) {
 }
 
 type ApiServerParams struct {
-	IssuerUrl      string `json:"--oidc-issuer-url,omitempty"`
-	ClientId       string `json:"--oidc-client-id,omitempty"`
-	UsernameClaim  string `json:"--oidc-username-claim,omitempty"`
-	UsernamePrefix string `json:"--oidc-username-prefix,omitempty"`
-	SigningAlgs    string `json:"--oidc-signing-algs,omitempty"`
-	GroupsClaim    string `json:"--oidc-groups-claim,omitempty"`
-	GroupsPrefix   string `json:"--oidc-groups-prefix,omitempty"`
+	IssuerUrl      *string `json:"--oidc-issuer-url,omitempty"`
+	ClientId       *string `json:"--oidc-client-id,omitempty"`
+	UsernameClaim  *string `json:"--oidc-username-claim,omitempty"`
+	UsernamePrefix *string `json:"--oidc-username-prefix,omitempty"`
+	SigningAlgs    *string `json:"--oidc-signing-algs,omitempty"`
+	GroupsClaim    *string `json:"--oidc-groups-claim,omitempty"`
+	GroupsPrefix   *string `json:"--oidc-groups-prefix,omitempty"`
 }
 
 type Kaas struct {

--- a/internal/services/kaas/kaas_data_source.go
+++ b/internal/services/kaas/kaas_data_source.go
@@ -121,7 +121,6 @@ func (d *kaasDataSource) Schema(ctx context.Context, _ datasource.SchemaRequest,
 						Attributes: map[string]schema.Attribute{
 							"ca": schema.StringAttribute{
 								Computed:            true,
-								Sensitive:           true,
 								Description:         "OIDC Ca Certificate",
 								MarkdownDescription: "OIDC Ca Certificate",
 							},

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -217,8 +217,7 @@ func (r *kaasResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 						Optional:            true,
 						Attributes: map[string]schema.Attribute{
 							"ca": schema.StringAttribute{
-								Optional:  true,
-								Sensitive: true,
+								Optional: true,
 								PlanModifiers: []planmodifier.String{
 									stringplanmodifier.UseStateForUnknown(),
 								},
@@ -396,13 +395,13 @@ func (state *KaasModel) updateOIDCConfig(apiserverParams *kaas.Apiserver) {
 	if apiserverParams.Params != nil {
 		params := apiserverParams.Params
 		state.Apiserver.Oidc = &OidcModel{
-			ClientId:       types.StringValue(params.ClientId),
-			IssuerUrl:      types.StringValue(params.IssuerUrl),
-			UsernameClaim:  types.StringValue(params.UsernameClaim),
-			UsernamePrefix: types.StringValue(params.UsernamePrefix),
-			SigningAlgs:    types.StringValue(params.SigningAlgs),
-			GroupsClaim:    types.StringValue(params.GroupsClaim),
-			GroupsPrefix:   types.StringValue(params.GroupsPrefix),
+			ClientId:       types.StringPointerValue(params.ClientId),
+			IssuerUrl:      types.StringPointerValue(params.IssuerUrl),
+			UsernameClaim:  types.StringPointerValue(params.UsernameClaim),
+			UsernamePrefix: types.StringPointerValue(params.UsernamePrefix),
+			SigningAlgs:    types.StringPointerValue(params.SigningAlgs),
+			GroupsClaim:    types.StringPointerValue(params.GroupsClaim),
+			GroupsPrefix:   types.StringPointerValue(params.GroupsPrefix),
 			Ca:             types.StringPointerValue(apiserverParams.OidcCa),
 		}
 	} else {
@@ -598,13 +597,13 @@ func (r *kaasResource) buildApiserverParamsInput(data KaasModel) *kaas.Apiserver
 	if data.Apiserver.Oidc != nil {
 		apiserverParamsInput.OidcCa = data.Apiserver.Oidc.Ca.ValueStringPointer()
 		apiserverParamsInput.Params = &kaas.ApiServerParams{
-			IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueString(),
-			ClientId:       data.Apiserver.Oidc.ClientId.ValueString(),
-			UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueString(),
-			UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueString(),
-			SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueString(),
-			GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueString(),
-			GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueString(),
+			IssuerUrl:      data.Apiserver.Oidc.IssuerUrl.ValueStringPointer(),
+			ClientId:       data.Apiserver.Oidc.ClientId.ValueStringPointer(),
+			UsernameClaim:  data.Apiserver.Oidc.UsernameClaim.ValueStringPointer(),
+			UsernamePrefix: data.Apiserver.Oidc.UsernamePrefix.ValueStringPointer(),
+			SigningAlgs:    data.Apiserver.Oidc.SigningAlgs.ValueStringPointer(),
+			GroupsClaim:    data.Apiserver.Oidc.GroupsClaim.ValueStringPointer(),
+			GroupsPrefix:   data.Apiserver.Oidc.GroupsPrefix.ValueStringPointer(),
 		}
 	}
 	return apiserverParamsInput


### PR DESCRIPTION
Closes #31

This PR allows to give optional apiserver parameters.
CA certificate is not a sensitive value anymore.