### PR TITLE
fix(kaas): kube version & instance failed quota

### DIFF
--- a/internal/apis/kaas/implementation/client.go
+++ b/internal/apis/kaas/implementation/client.go
@@ -316,7 +316,6 @@ func (client *Client) PatchIPFilters(cidrs []string, publicCloudId int, projectI
 		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
 		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
 		SetBody(body).
-		SetDebug(true).
 		SetResult(&result).
 		SetError(&result).
 		Put(EndpointIPFilter)
@@ -338,7 +337,6 @@ func (client *Client) GetIPFilters(publicCloudId int, projectId int, kaasId int)
 		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
 		SetPathParam("public_cloud_project_id", fmt.Sprint(projectId)).
 		SetPathParam("kaas_id", fmt.Sprint(kaasId)).
-		SetDebug(true).
 		SetResult(&result).
 		SetError(&result).
 		Get(EndpointIPFilter)

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -89,6 +89,8 @@ type InstancePool struct {
 
 	TargetInstances    int32 `json:"target_instances,omitempty"`
 	AvailableInstances int32 `json:"available_instances,omitempty"`
+
+	ErrorMessages []string `json:"error_messages,omitempty"`
 }
 
 func (instancePool *InstancePool) Key() string {

--- a/internal/services/kaas/kaas_instance_pool_resource.go
+++ b/internal/services/kaas/kaas_instance_pool_resource.go
@@ -247,6 +247,10 @@ func (r *kaasInstancePoolResource) waitUntilActive(ctx context.Context, data Kaa
 			return nil, nil
 		}
 
+		if len(found.ErrorMessages) > 0 {
+			return nil, errors.New(strings.Join(found.ErrorMessages, ","))
+		}
+
 		// We need the instance pool to be active, have the same state as us, be scaled properly and be in bound of the autoscaling
 		isActive := found.Status == "Active"
 		isEquivalent := found.MinInstances == data.MinInstances.ValueInt32()

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -343,15 +343,9 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	// Wait for kubeconfig to be available
-	kubeconfig, err := r.client.Kaas.GetKubeconfig(int(data.PublicCloudId.ValueInt64()), int(data.PublicCloudProjectId.ValueInt64()), kaasId)
+	err = r.fetchAndSetKubeconfig(&data, input)
 	if err != nil {
-		resp.Diagnostics.AddWarning(
-			"Could not get kubeconfig for KaaS",
-			err.Error(),
-		)
-	} else {
-		data.Kubeconfig = types.StringValue(kubeconfig)
+		resp.Diagnostics.AddWarning("could not fetch and set kubeconfig", err.Error())
 	}
 
 	data.fill(kaasObject)
@@ -511,15 +505,9 @@ func (r *kaasResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	state.fill(kaasObject)
 
-	// Wait for kubeconfig to be available
-	kubeconfig, err := r.client.Kaas.GetKubeconfig(int(state.PublicCloudId.ValueInt64()), int(state.PublicCloudProjectId.ValueInt64()), kaasObject.Id)
+	err = r.fetchAndSetKubeconfig(&state, kaasObject)
 	if err != nil {
-		resp.Diagnostics.AddWarning(
-			"Could not get kubeconfig",
-			err.Error(),
-		)
-	} else {
-		state.Kubeconfig = types.StringValue(kubeconfig)
+		resp.Diagnostics.AddWarning("could not fetch and set kubeconfig", err.Error())
 	}
 
 	apiserverParams, err := r.client.Kaas.GetApiserverParams(int(state.PublicCloudId.ValueInt64()), int(state.PublicCloudProjectId.ValueInt64()), kaasObject.Id)
@@ -551,7 +539,6 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	var state KaasModel
 	var data KaasModel
 
-	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 
@@ -564,7 +551,34 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	// Update API call logic
+	input := r.prepareUpdateInput(state, data, chosenPackState.Id)
+
+	if _, err := r.client.Kaas.UpdateKaas(input); err != nil {
+		resp.Diagnostics.AddError("Error when updating KaaS", err.Error())
+		return
+	}
+
+	kaasObject, err := r.waitUntilActive(ctx, input, input.Id)
+	if err != nil || kaasObject == nil {
+		resp.Diagnostics.AddError("Error waiting for KaaS activation", err.Error())
+		return
+	}
+
+	err = r.fetchAndSetKubeconfig(&data, input)
+	if err != nil {
+		resp.Diagnostics.AddWarning("could not fetch and set kubeconfig", err.Error())
+	}
+
+	data.fill(kaasObject)
+
+	if data.Apiserver != nil {
+		r.handleApiserverConfig(ctx, &data, input, resp)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *kaasResource) prepareUpdateInput(state, data KaasModel, packID int) *kaas.Kaas {
 	input := &kaas.Kaas{
 		Project: kaas.KaasProject{
 			PublicCloudId: int(data.PublicCloudId.ValueInt64()),
@@ -572,7 +586,7 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		},
 		Id:                int(state.Id.ValueInt64()),
 		Name:              data.Name.ValueString(),
-		PackId:            chosenPackState.Id,
+		PackId:            packID,
 		Region:            state.Region.ValueString(),
 		KubernetesVersion: data.KubernetesVersion.ValueString(),
 	}
@@ -581,78 +595,49 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		input.KubernetesVersion = ""
 	}
 
-	_, err = r.client.Kaas.UpdateKaas(input)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error when updating KaaS",
-			err.Error(),
-		)
-		return
-	}
+	return input
+}
 
-	kaasObject, err := r.waitUntilActive(ctx, input, input.Id)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error when getting KaaS",
-			err.Error(),
-		)
-		return
-	}
-
-	if kaasObject == nil {
-		return
-	}
-
-	// Wait for kubeconfig to be available
+func (r *kaasResource) fetchAndSetKubeconfig(data *KaasModel, input *kaas.Kaas) error {
 	kubeconfig, err := r.client.Kaas.GetKubeconfig(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		input.Project.PublicCloudId,
+		input.Project.ProjectId,
+		input.Id,
 	)
 	if err != nil {
-		resp.Diagnostics.AddWarning(
-			"Could not get kubeconfig",
-			err.Error(),
-		)
-	} else {
-		data.Kubeconfig = types.StringValue(kubeconfig)
+		return fmt.Errorf("could not get kubeconfig: %w", err)
 	}
+	data.Kubeconfig = types.StringValue(kubeconfig)
+	return nil
+}
 
-	data.fill(kaasObject)
+func (r *kaasResource) handleApiserverConfig(ctx context.Context, data *KaasModel, input *kaas.Kaas, resp *resource.UpdateResponse) {
+	apiserverParamsInput := r.buildApiserverParamsInput(*data)
+	patched, err := r.client.Kaas.PatchApiserverParams(apiserverParamsInput, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
+	if !patched || err != nil {
+		resp.Diagnostics.AddError("Error when patching Apiserver params", err.Error())
+		return
+	}
+	data.fillApiserverState(ctx, apiserverParamsInput)
 
-	if data.Apiserver != nil {
-		apiserverParamsInput := r.buildApiserverParamsInput(data)
-		patched, err := r.client.Kaas.PatchApiserverParams(apiserverParamsInput, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
-		if !patched || err != nil {
-			resp.Diagnostics.AddError(
-				"Error when creating Oidc",
-				err.Error(),
-			)
+	if !data.Apiserver.AllowRequestsFromCIDR.IsNull() {
+		allowedCidrs := make([]string, 0, len(data.Apiserver.AllowRequestsFromCIDR.Elements()))
+		resp.Diagnostics.Append(data.Apiserver.AllowRequestsFromCIDR.ElementsAs(ctx, &allowedCidrs, true)...)
+		if resp.Diagnostics.HasError() {
 			return
 		}
-		data.fillApiserverState(ctx, apiserverParamsInput)
 
-		if !data.Apiserver.AllowRequestsFromCIDR.IsNull() {
-			allowedCidrs := make([]string, 0, len(data.Apiserver.AllowRequestsFromCIDR.Elements()))
-			resp.Diagnostics.Append(data.Apiserver.AllowRequestsFromCIDR.ElementsAs(ctx, &allowedCidrs, true)...)
-			ok, err := r.client.Kaas.PatchIPFilters(allowedCidrs, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
-			if !ok || err != nil {
-				var errMsg string
-				if err != nil {
-					errMsg = err.Error()
-				} else {
-					errMsg = "PatchIPFilters returned false but no error was provided"
-				}
-				resp.Diagnostics.AddError(
-					"Error when applying network filtering",
-					errMsg,
-				)
+		ok, err := r.client.Kaas.PatchIPFilters(allowedCidrs, input.Project.PublicCloudId, input.Project.ProjectId, input.Id)
+		if !ok || err != nil {
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			} else {
+				errMsg = "PatchIPFilters returned false but no error was provided"
 			}
+			resp.Diagnostics.AddError("Error when applying network filtering", errMsg)
 		}
-
 	}
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *kaasResource) buildApiserverParamsInput(data KaasModel) *kaas.Apiserver {

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -574,7 +574,7 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		Name:              data.Name.ValueString(),
 		PackId:            chosenPackState.Id,
 		Region:            state.Region.ValueString(),
-		KubernetesVersion: state.KubernetesVersion.ValueString(),
+		KubernetesVersion: data.KubernetesVersion.ValueString(),
 	}
 
 	_, err = r.client.Kaas.UpdateKaas(input)

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -577,6 +577,10 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		KubernetesVersion: data.KubernetesVersion.ValueString(),
 	}
 
+	if state.KubernetesVersion.ValueString() == data.KubernetesVersion.ValueString() {
+		input.KubernetesVersion = ""
+	}
+
 	_, err = r.client.Kaas.UpdateKaas(input)
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
This PR fixes an issue. We were taking kube version from state and not from new values, so it could not be updated.
It also fixes an issue where if openstack quota is exceeded, no error was detected