### PR TITLE
fix: repair list of record types adding NS type

### DIFF
--- a/internal/apis/domain/models.go
+++ b/internal/apis/domain/models.go
@@ -33,7 +33,7 @@ var (
 	RecordTXT    RecordType = "TXT"
 )
 
-var RecordTypes = []RecordType{RecordA, RecordAAAA, RecordCAA, RecordCNAME, RecordDNAME, RecordDS, RecordMX, RecordSMIMEA, RecordSRV, RecordSSHFP, RecordTLSA, RecordTXT}
+var RecordTypes = []RecordType{RecordA, RecordAAAA, RecordCAA, RecordCNAME, RecordDNAME, RecordNS, RecordDS, RecordMX, RecordSMIMEA, RecordSRV, RecordSSHFP, RecordTLSA, RecordTXT}
 
 func IsValidRecordType(t RecordType) bool {
 	return slices.Contains(RecordTypes, t)


### PR DESCRIPTION
My enormous contribution for the domain service. 
While playing around, i realized that the NS records were not managed. This was tested succesfully on my side.

```
...[truncated]
  # infomaniak_record.record["data.magellan.tf-root-scsnms.switch.ch"] will be created
  + resource "infomaniak_record" "record" {
      + computed_target = "scsnms.switch.ch"
      + id              = (known after apply)
      + target          = "scsnms.switch.ch"
      + ttl             = 3600
      + type            = "NS"
      + zone_fqdn       = "data.magellan.tf"
...[truncated]
infomaniak_record.record["data.magellan.tf-root-scsnms.switch.ch"]: Creating...
infomaniak_record.record["data.magellan.tf-root-scsnms.switch.ch"]: Creation complete after 1s
...[truncated]
```