### PR TITLE
refactor: only use int64

### DIFF
--- a/internal/apis/dbaas/implementation/client.go
+++ b/internal/apis/dbaas/implementation/client.go
@@ -51,7 +51,7 @@ func (client *Client) FindPack(dbType string, name string) (*dbaas.DBaaSPack, er
 	return data[0], nil
 }
 
-func (client *Client) GetDBaaS(publicCloudId int, publicCloudProjectId int, dbaasId int) (*dbaas.DBaaS, error) {
+func (client *Client) GetDBaaS(publicCloudId int64, publicCloudProjectId int64, dbaasId int64) (*dbaas.DBaaS, error) {
 	var result helpers.NormalizedApiResponse[*dbaas.DBaaS]
 
 	resp, err := client.resty.R().
@@ -116,7 +116,7 @@ func (client *Client) UpdateDBaaS(input *dbaas.DBaaS) (bool, error) {
 	return result.Data, nil
 }
 
-func (client *Client) DeleteDBaaS(publicCloudId int, publicCloudProjectId int, dbaasId int) (bool, error) {
+func (client *Client) DeleteDBaaS(publicCloudId int64, publicCloudProjectId int64, dbaasId int64) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -137,7 +137,7 @@ func (client *Client) DeleteDBaaS(publicCloudId int, publicCloudProjectId int, d
 	return result.Data, nil
 }
 
-func (client *Client) PatchIpFilters(publicCloudId int, publicCloudProjectId int, dbaasId int, filters dbaas.AllowedCIDRs) (bool, error) {
+func (client *Client) PatchIpFilters(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, filters dbaas.AllowedCIDRs) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -159,7 +159,7 @@ func (client *Client) PatchIpFilters(publicCloudId int, publicCloudProjectId int
 	return result.Data, nil
 }
 
-func (client *Client) GetIpFilters(publicCloudId int, publicCloudProjectId int, dbaasId int) ([]string, error) {
+func (client *Client) GetIpFilters(publicCloudId int64, publicCloudProjectId int64, dbaasId int64) ([]string, error) {
 	var result helpers.NormalizedApiResponse[[]string]
 
 	resp, err := client.resty.R().
@@ -180,7 +180,7 @@ func (client *Client) GetIpFilters(publicCloudId int, publicCloudProjectId int, 
 	return result.Data, nil
 }
 
-func (client *Client) CreateDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, backupSchedules *dbaas.DBaasBackupSchedule) (*dbaas.DBaasBackupScheduleCreateInfo, error) {
+func (client *Client) CreateDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, backupSchedules *dbaas.DBaasBackupSchedule) (*dbaas.DBaasBackupScheduleCreateInfo, error) {
 	var result helpers.NormalizedApiResponse[*dbaas.DBaasBackupScheduleCreateInfo]
 
 	resp, err := client.resty.R().
@@ -202,7 +202,7 @@ func (client *Client) CreateDBaasScheduleBackup(publicCloudId int, publicCloudPr
 	return result.Data, nil
 }
 
-func (client *Client) UpdateDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int, backupSchedules *dbaas.DBaasBackupSchedule) (bool, error) {
+func (client *Client) UpdateDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64, backupSchedules *dbaas.DBaasBackupSchedule) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -225,7 +225,7 @@ func (client *Client) UpdateDBaasScheduleBackup(publicCloudId int, publicCloudPr
 	return result.Data, nil
 }
 
-func (client *Client) GetDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int) (*dbaas.DBaasBackupSchedule, error) {
+func (client *Client) GetDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64) (*dbaas.DBaasBackupSchedule, error) {
 	var result helpers.NormalizedApiResponse[*dbaas.DBaasBackupSchedule]
 
 	resp, err := client.resty.R().
@@ -247,7 +247,7 @@ func (client *Client) GetDBaasScheduleBackup(publicCloudId int, publicCloudProje
 	return result.Data, nil
 }
 
-func (client *Client) DeleteDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int) (bool, error) {
+func (client *Client) DeleteDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().

--- a/internal/apis/dbaas/models.go
+++ b/internal/apis/dbaas/models.go
@@ -7,7 +7,7 @@ import (
 )
 
 type DBaaSPack struct {
-	Id   int    `json:"id,omitempty"`
+	Id   int64  `json:"id,omitempty"`
 	Name string `json:"name,omitempty"`
 }
 
@@ -17,13 +17,13 @@ type DbaasType struct {
 }
 
 type Pack struct {
-	ID        int32  `json:"id,omitempty"`
+	ID        int64  `json:"id,omitempty"`
 	Type      string `json:"type,omitempty"`
 	Group     string `json:"group,omitempty"`
 	Name      string `json:"name,omitempty"`
-	Instances int32  `json:"instances,omitempty"`
-	CPU       int32  `json:"cpu,omitempty"`
-	RAM       int32  `json:"ram,omitempty"`
+	Instances int64  `json:"instances,omitempty"`
+	CPU       int64  `json:"cpu,omitempty"`
+	RAM       int64  `json:"ram,omitempty"`
 	Storage   int64  `json:"storage,omitempty"`
 	Rates     Rates  `json:"rates"`
 }
@@ -39,9 +39,9 @@ type Pricing struct {
 }
 
 type DBaaS struct {
-	Id         int                  `json:"id,omitempty"`
+	Id         int64                `json:"id,omitempty"`
 	Project    DBaaSProject         `json:"project,omitzero"`
-	PackId     int                  `json:"pack_id,omitempty"`
+	PackId     int64                `json:"pack_id,omitempty"`
 	Pack       *DBaaSPack           `json:"pack,omitempty"`
 	Connection *DBaaSConnectionInfo `json:"connection,omitempty"`
 
@@ -90,7 +90,7 @@ type DBaasBackupSchedule struct {
 	Id            *int64  `json:"id,omitempty"`
 	Name          *string `json:"name,omitempty"`
 	Time          *string `json:"time,omitempty"`
-	Keep          *int32  `json:"keep,omitempty"`
+	Keep          *int64  `json:"keep,omitempty"`
 	IsPitrEnabled *bool   `json:"is_pitr_enabled,omitempty"`
 }
 
@@ -99,7 +99,7 @@ type DBaasBackupScheduleCreateInfo struct {
 }
 
 type DBaaSCreateInfo struct {
-	Id             int    `json:"id"`
+	Id             int64  `json:"id"`
 	RootPassword   string `json:"root_password"`
 	KubeIdentifier string `json:"kube_identifier"`
 }
@@ -133,6 +133,6 @@ func (dbaas *DBaaS) Key() string {
 }
 
 type DBaaSProject struct {
-	PublicCloudId int `json:"public_cloud_id,omitempty"`
-	ProjectId     int `json:"id,omitempty"`
+	PublicCloudId int64 `json:"public_cloud_id,omitempty"`
+	ProjectId     int64 `json:"id,omitempty"`
 }

--- a/internal/apis/dbaas/spec.go
+++ b/internal/apis/dbaas/spec.go
@@ -3,18 +3,18 @@ package dbaas
 type Api interface {
 	FindPack(dbType string, name string) (*DBaaSPack, error)
 
-	GetDBaaS(publicCloudId int, publicCloudProjectId int, DBaaSId int) (*DBaaS, error)
+	GetDBaaS(publicCloudId int64, publicCloudProjectId int64, DBaaSId int64) (*DBaaS, error)
 	CreateDBaaS(input *DBaaS) (*DBaaSCreateInfo, error)
 	UpdateDBaaS(input *DBaaS) (bool, error)
-	DeleteDBaaS(publicCloudId int, publicCloudProjectId int, DBaaSId int) (bool, error)
+	DeleteDBaaS(publicCloudId int64, publicCloudProjectId int64, DBaaSId int64) (bool, error)
 
-	PatchIpFilters(publicCloudId int, publicCloudProjectId int, dbaasId int, filters AllowedCIDRs) (bool, error)
-	GetIpFilters(publicCloudId int, publicCloudProjectId int, dbaasId int) ([]string, error)
+	PatchIpFilters(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, filters AllowedCIDRs) (bool, error)
+	GetIpFilters(publicCloudId int64, publicCloudProjectId int64, dbaasId int64) ([]string, error)
 
-	GetDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int) (*DBaasBackupSchedule, error)
-	CreateDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, backupSchedules *DBaasBackupSchedule) (*DBaasBackupScheduleCreateInfo, error)
-	UpdateDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int, backupSchedules *DBaasBackupSchedule) (bool, error)
-	DeleteDBaasScheduleBackup(publicCloudId int, publicCloudProjectId int, dbaasId int, id int) (bool, error)
+	GetDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64) (*DBaasBackupSchedule, error)
+	CreateDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, backupSchedules *DBaasBackupSchedule) (*DBaasBackupScheduleCreateInfo, error)
+	UpdateDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64, backupSchedules *DBaasBackupSchedule) (bool, error)
+	DeleteDBaasScheduleBackup(publicCloudId int64, publicCloudProjectId int64, dbaasId int64, id int64) (bool, error)
 
 	GetDbaasRegions() ([]string, error)
 	GetDbaasTypes() ([]*DbaasType, error)

--- a/internal/apis/domain/models.go
+++ b/internal/apis/domain/models.go
@@ -3,7 +3,7 @@ package domain
 import "slices"
 
 type Zone struct {
-	ID             int        `json:"id,omitempty"`
+	ID             int64      `json:"id,omitempty"`
 	FQDN           string     `json:"fqdn,omitempty"`
 	DNSSEC         ZoneDNSSEC `json:"dnssec,omitempty"`
 	Nameservers    []string   `json:"nameservers,omitempty"`
@@ -40,13 +40,13 @@ func IsValidRecordType(t RecordType) bool {
 }
 
 type Record struct {
-	ID        int        `json:"id,omitempty"`
+	ID        int64      `json:"id,omitempty"`
 	Source    string     `json:"source,omitempty"`
 	SourceIDN *string    `json:"source_idn,omitempty"`
 	Type      RecordType `json:"type,omitempty"`
-	TTL       int        `json:"ttl,omitempty"`
+	TTL       int64      `json:"ttl,omitempty"`
 	Target    string     `json:"target,omitempty"`
-	DynDNSID  int        `json:"dyndns_id,omitempty"`
+	DynDNSID  int64      `json:"dyndns_id,omitempty"`
 	// Description string     `json:"description,omitempty"`
 }
 

--- a/internal/apis/kaas/implementation/client.go
+++ b/internal/apis/kaas/implementation/client.go
@@ -62,7 +62,7 @@ func (client *Client) GetVersions() ([]string, error) {
 	return result.Data, nil
 }
 
-func (client *Client) GetKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (*kaas.Kaas, error) {
+func (client *Client) GetKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (*kaas.Kaas, error) {
 	var result helpers.NormalizedApiResponse[*kaas.Kaas]
 
 	resp, err := client.resty.R().
@@ -84,7 +84,7 @@ func (client *Client) GetKaas(publicCloudId int, publicCloudProjectId int, kaasI
 	return result.Data, nil
 }
 
-func (client *Client) GetKubeconfig(publicCloudId int, publicCloudProjectId int, kaasId int) (string, error) {
+func (client *Client) GetKubeconfig(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (string, error) {
 	var result helpers.NormalizedApiResponse[string]
 
 	resp, err := client.resty.R().
@@ -105,8 +105,8 @@ func (client *Client) GetKubeconfig(publicCloudId int, publicCloudProjectId int,
 	return result.Data, nil
 }
 
-func (client *Client) CreateKaas(input *kaas.Kaas) (int, error) {
-	var result helpers.NormalizedApiResponse[int]
+func (client *Client) CreateKaas(input *kaas.Kaas) (int64, error) {
+	var result helpers.NormalizedApiResponse[int64]
 
 	resp, err := client.resty.R().
 		SetPathParam("public_cloud_id", fmt.Sprint(input.Project.PublicCloudId)).
@@ -148,7 +148,7 @@ func (client *Client) UpdateKaas(input *kaas.Kaas) (bool, error) {
 	return result.Data, nil
 }
 
-func (client *Client) DeleteKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (bool, error) {
+func (client *Client) DeleteKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -169,7 +169,7 @@ func (client *Client) DeleteKaas(publicCloudId int, publicCloudProjectId int, ka
 	return result.Data, nil
 }
 
-func (client *Client) GetInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (*kaas.InstancePool, error) {
+func (client *Client) GetInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (*kaas.InstancePool, error) {
 	var result helpers.NormalizedApiResponse[*kaas.InstancePool]
 
 	resp, err := client.resty.R().
@@ -196,8 +196,8 @@ func (client *Client) GetInstancePool(publicCloudId int, publicCloudProjectId in
 	return result.Data, nil
 }
 
-func (client *Client) CreateInstancePool(publicCloudId int, publicCloudProjectId int, input *kaas.InstancePool) (int, error) {
-	var result helpers.NormalizedApiResponse[int]
+func (client *Client) CreateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *kaas.InstancePool) (int64, error) {
+	var result helpers.NormalizedApiResponse[int64]
 
 	resp, err := client.resty.R().
 		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
@@ -218,7 +218,7 @@ func (client *Client) CreateInstancePool(publicCloudId int, publicCloudProjectId
 	return result.Data, nil
 }
 
-func (client *Client) UpdateInstancePool(publicCloudId int, publicCloudProjectId int, input *kaas.InstancePool) (bool, error) {
+func (client *Client) UpdateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *kaas.InstancePool) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -241,7 +241,7 @@ func (client *Client) UpdateInstancePool(publicCloudId int, publicCloudProjectId
 	return result.Data, nil
 }
 
-func (client *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (bool, error) {
+func (client *Client) DeleteInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 
 	resp, err := client.resty.R().
@@ -263,7 +263,7 @@ func (client *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId
 	return result.Data, nil
 }
 
-func (client *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+func (client *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int64, projectId int64, kaasId int64) (bool, error) {
 	var result helpers.NormalizedApiResponse[bool]
 	resp, err := client.resty.R().
 		SetPathParam("public_cloud_id", fmt.Sprint(publicCloudId)).
@@ -285,7 +285,7 @@ func (client *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId 
 	return result.Data, nil
 }
 
-func (client *Client) GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*kaas.Apiserver, error) {
+func (client *Client) GetApiserverParams(publicCloudId int64, projectId int64, kaasId int64) (*kaas.Apiserver, error) {
 
 	var result helpers.NormalizedApiResponse[*kaas.Apiserver]
 	resp, err := client.resty.R().

--- a/internal/apis/kaas/implementation/client_test.go
+++ b/internal/apis/kaas/implementation/client_test.go
@@ -78,7 +78,7 @@ var _ = Describe("KaaS API Client", func() {
 			httpmock.ActivateNonDefault(client.resty.Client())
 			defer httpmock.DeactivateAndReset()
 
-			expectedResult := 12
+			expectedResult := int64(12)
 
 			httpmock.RegisterResponder("POST", TestEndpointKaases, httpmock.NewJsonResponderOrPanic(200, NewSuccessResponse(expectedResult)))
 

--- a/internal/apis/kaas/mock/client.go
+++ b/internal/apis/kaas/mock/client.go
@@ -35,7 +35,7 @@ func (c *Client) GetPacks() ([]*kaas.KaasPack, error) {
 	}, nil
 }
 
-func (c *Client) MustGetPackFromId(id int) *kaas.KaasPack {
+func (c *Client) MustGetPackFromId(id int64) *kaas.KaasPack {
 	packs, _ := c.GetPacks()
 	for _, pack := range packs {
 		if pack.Id == id {
@@ -50,7 +50,7 @@ func (c *Client) GetVersions() ([]string, error) {
 	return []string{"1.29", "1.30", "1.31"}, nil
 }
 
-func (c *Client) GetKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (*kaas.Kaas, error) {
+func (c *Client) GetKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (*kaas.Kaas, error) {
 	key := fmt.Sprintf("%d-%d-%d", publicCloudId, publicCloudProjectId, kaasId)
 	obj, err := getFromCache[*kaas.Kaas](key)
 	if err != nil {
@@ -62,11 +62,11 @@ func (c *Client) GetKaas(publicCloudId int, publicCloudProjectId int, kaasId int
 	return obj, nil
 }
 
-func (client *Client) GetKubeconfig(publicCloudId int, publicCloudProjectId int, kaasId int) (string, error) {
+func (client *Client) GetKubeconfig(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (string, error) {
 	return genKubeconfig(), nil
 }
 
-func (c *Client) CreateKaas(input *kaas.Kaas) (int, error) {
+func (c *Client) CreateKaas(input *kaas.Kaas) (int64, error) {
 	// Checks
 	if input.Project.PublicCloudId == 0 {
 		return 0, fmt.Errorf("kaas is missing public cloud project id")
@@ -120,7 +120,7 @@ func (c *Client) UpdateKaas(input *kaas.Kaas) (bool, error) {
 	return true, updateCache(&obj)
 }
 
-func (c *Client) DeleteKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (bool, error) {
+func (c *Client) DeleteKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (bool, error) {
 	var obj = kaas.Kaas{
 		Project: kaas.KaasProject{
 			PublicCloudId: publicCloudId,
@@ -132,7 +132,7 @@ func (c *Client) DeleteKaas(publicCloudId int, publicCloudProjectId int, kaasId 
 	return true, removeFromCache(&obj)
 }
 
-func (c *Client) GetInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (*kaas.InstancePool, error) {
+func (c *Client) GetInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (*kaas.InstancePool, error) {
 	_, err := c.GetKaas(publicCloudId, publicCloudProjectId, kaasId)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (c *Client) GetInstancePool(publicCloudId int, publicCloudProjectId int, ka
 	return obj, nil
 }
 
-func (c *Client) CreateInstancePool(publicCloudId int, publicCloudProjectId int, input *kaas.InstancePool) (int, error) {
+func (c *Client) CreateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *kaas.InstancePool) (int64, error) {
 	// Checks
 	if publicCloudId == 0 {
 		return 0, fmt.Errorf("instance pool is missing public cloud id")
@@ -206,7 +206,7 @@ func (c *Client) CreateInstancePool(publicCloudId int, publicCloudProjectId int,
 	return obj.Id, addToCache(&obj)
 }
 
-func (c *Client) UpdateInstancePool(publicCloudId int, publicCloudProjectId int, input *kaas.InstancePool) (bool, error) {
+func (c *Client) UpdateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *kaas.InstancePool) (bool, error) {
 	// Checks
 	if publicCloudId == 0 {
 		return false, fmt.Errorf("instance pool is missing public cloud id")
@@ -262,7 +262,7 @@ func (c *Client) UpdateInstancePool(publicCloudId int, publicCloudProjectId int,
 	return true, updateCache(&obj)
 }
 
-func (c *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (bool, error) {
+func (c *Client) DeleteInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (bool, error) {
 	_, err := c.GetKaas(publicCloudId, publicCloudProjectId, kaasId)
 	if err != nil {
 		return false, err
@@ -276,9 +276,9 @@ func (c *Client) DeleteInstancePool(publicCloudId int, publicCloudProjectId int,
 	return true, removeFromCache(&obj)
 }
 
-func (c *Client) GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*kaas.Apiserver, error) {
+func (c *Client) GetApiserverParams(publicCloudId int64, projectId int64, kaasId int64) (*kaas.Apiserver, error) {
 	return nil, nil
 }
-func (c *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error) {
+func (c *Client) PatchApiserverParams(input *kaas.Apiserver, publicCloudId int64, projectId int64, kaasId int64) (bool, error) {
 	return true, nil
 }

--- a/internal/apis/kaas/mock/gen.go
+++ b/internal/apis/kaas/mock/gen.go
@@ -7,8 +7,8 @@ import (
 	"math/rand/v2"
 )
 
-func genId() int {
-	return rand.Int()
+func genId() int64 {
+	return rand.Int64()
 }
 
 func genKubeconfig() string {

--- a/internal/apis/kaas/models.go
+++ b/internal/apis/kaas/models.go
@@ -7,7 +7,7 @@ import (
 )
 
 type KaasPack struct {
-	Id          int    `json:"kaas_pack_id,omitempty"`
+	Id          int64  `json:"kaas_pack_id,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 }
@@ -57,9 +57,9 @@ type ApiServerParams struct {
 
 type Kaas struct {
 	Name    string      `json:"name,omitempty"`
-	Id      int         `json:"kaas_id,omitempty"`
+	Id      int64       `json:"kaas_id,omitempty"`
 	Project KaasProject `json:"project,omitzero"`
-	PackId  int         `json:"kaas_pack_id,omitempty"`
+	PackId  int64       `json:"kaas_pack_id,omitempty"`
 	Pack    *KaasPack   `json:"pack,omitempty"`
 
 	Region            string `json:"region,omitempty"`
@@ -72,24 +72,24 @@ func (kaas *Kaas) Key() string {
 }
 
 type KaasProject struct {
-	PublicCloudId int `json:"public_cloud_id,omitempty"`
-	ProjectId     int `json:"id,omitempty"`
+	PublicCloudId int64 `json:"public_cloud_id,omitempty"`
+	ProjectId     int64 `json:"id,omitempty"`
 }
 
 type InstancePool struct {
-	KaasId int `json:"kaas_id,omitempty"`
-	Id     int `json:"instance_pool_id,omitempty"`
+	KaasId int64 `json:"kaas_id,omitempty"`
+	Id     int64 `json:"instance_pool_id,omitempty"`
 
 	Name             string            `json:"name,omitempty"`
 	FlavorName       string            `json:"flavor,omitempty"`
 	AvailabilityZone string            `json:"availability_zone,omitempty"`
-	MinInstances     int32             `json:"minimum_instances,omitempty"`
-	MaxInstances     int32             `json:"maximum_instances,omitempty"`
+	MinInstances     int64             `json:"minimum_instances,omitempty"`
+	MaxInstances     int64             `json:"maximum_instances,omitempty"`
 	Status           string            `json:"status,omitempty"`
 	Labels           map[string]string `json:"labels,omitempty"`
 
-	TargetInstances    int32 `json:"target_instances,omitempty"`
-	AvailableInstances int32 `json:"available_instances,omitempty"`
+	TargetInstances    int64 `json:"target_instances,omitempty"`
+	AvailableInstances int64 `json:"available_instances,omitempty"`
 
 	ErrorMessages []string `json:"error_messages,omitempty"`
 }

--- a/internal/apis/kaas/spec.go
+++ b/internal/apis/kaas/spec.go
@@ -4,18 +4,18 @@ type Api interface {
 	GetPacks() ([]*KaasPack, error)
 	GetVersions() ([]string, error)
 
-	GetKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (*Kaas, error)
-	CreateKaas(input *Kaas) (int, error)
+	GetKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (*Kaas, error)
+	CreateKaas(input *Kaas) (int64, error)
 	UpdateKaas(input *Kaas) (bool, error)
-	DeleteKaas(publicCloudId int, publicCloudProjectId int, kaasId int) (bool, error)
+	DeleteKaas(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (bool, error)
 
-	GetKubeconfig(publicCloudId int, publicCloudProjectId int, kaasId int) (string, error)
+	GetKubeconfig(publicCloudId int64, publicCloudProjectId int64, kaasId int64) (string, error)
 
-	GetInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (*InstancePool, error)
-	CreateInstancePool(publicCloudId int, publicCloudProjectId int, input *InstancePool) (int, error)
-	UpdateInstancePool(publicCloudId int, publicCloudProjectId int, input *InstancePool) (bool, error)
-	DeleteInstancePool(publicCloudId int, publicCloudProjectId int, kaasId int, instancePoolId int) (bool, error)
+	GetInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (*InstancePool, error)
+	CreateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *InstancePool) (int64, error)
+	UpdateInstancePool(publicCloudId int64, publicCloudProjectId int64, input *InstancePool) (bool, error)
+	DeleteInstancePool(publicCloudId int64, publicCloudProjectId int64, kaasId int64, instancePoolId int64) (bool, error)
 
-	GetApiserverParams(publicCloudId int, projectId int, kaasId int) (*Apiserver, error)
-	PatchApiserverParams(input *Apiserver, publicCloudId int, projectId int, kaasId int) (bool, error)
+	GetApiserverParams(publicCloudId int64, projectId int64, kaasId int64) (*Apiserver, error)
+	PatchApiserverParams(input *Apiserver, publicCloudId int64, projectId int64, kaasId int64) (bool, error)
 }

--- a/internal/services/dbaas/dbaas_backup_schedule_resource.go
+++ b/internal/services/dbaas/dbaas_backup_schedule_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -44,14 +43,14 @@ type DBaasBackupScheduleModel struct {
 	Name               types.String `tfsdk:"name"`
 	AddDefaultSchedule types.Bool   `tfsdk:"add_default_schedule"`
 	Time               types.String `tfsdk:"time"`
-	Keep               types.Int32  `tfsdk:"keep"`
+	Keep               types.Int64  `tfsdk:"keep"`
 	IsPitrEnabled      types.Bool   `tfsdk:"is_pitr_enabled"`
 }
 
 func (model *DBaasBackupScheduleModel) fill(backupSchedule *dbaas.DBaasBackupSchedule) {
 	model.AddDefaultSchedule = types.BoolPointerValue(backupSchedule.AddDefaultSchedule)
 	model.Time = types.StringPointerValue(backupSchedule.Time)
-	model.Keep = types.Int32PointerValue(backupSchedule.Keep)
+	model.Keep = types.Int64PointerValue(backupSchedule.Keep)
 	model.IsPitrEnabled = types.BoolPointerValue(backupSchedule.IsPitrEnabled)
 	model.Name = types.StringPointerValue(backupSchedule.Name)
 	model.Id = types.Int64PointerValue(backupSchedule.Id)
@@ -133,11 +132,11 @@ func (r *dbaasBackupScheduleResource) Schema(ctx context.Context, req resource.S
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"keep": schema.Int32Attribute{
+			"keep": schema.Int64Attribute{
 				Optional:            true,
 				MarkdownDescription: "The number of backups to keep for the schedule",
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.UseStateForUnknown(),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"is_pitr_enabled": schema.BoolAttribute{
@@ -164,14 +163,14 @@ func (r *dbaasBackupScheduleResource) Create(ctx context.Context, req resource.C
 	input := &dbaas.DBaasBackupSchedule{
 		AddDefaultSchedule: data.AddDefaultSchedule.ValueBoolPointer(),
 		Time:               data.Time.ValueStringPointer(),
-		Keep:               data.Keep.ValueInt32Pointer(),
+		Keep:               data.Keep.ValueInt64Pointer(),
 		IsPitrEnabled:      data.IsPitrEnabled.ValueBoolPointer(),
 	}
 
 	created, err := r.client.DBaas.CreateDBaasScheduleBackup(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.DbaasId.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.DbaasId.ValueInt64(),
 		input,
 	)
 	if err != nil {
@@ -185,10 +184,10 @@ func (r *dbaasBackupScheduleResource) Create(ctx context.Context, req resource.C
 	data.Id = types.Int64Value(created.Id)
 
 	scheduleBackup, err := r.client.DBaas.GetDBaasScheduleBackup(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.DbaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.DbaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -218,15 +217,15 @@ func (r *dbaasBackupScheduleResource) Update(ctx context.Context, req resource.U
 	input := &dbaas.DBaasBackupSchedule{
 		AddDefaultSchedule: data.AddDefaultSchedule.ValueBoolPointer(),
 		Time:               data.Time.ValueStringPointer(),
-		Keep:               data.Keep.ValueInt32Pointer(),
+		Keep:               data.Keep.ValueInt64Pointer(),
 		IsPitrEnabled:      data.IsPitrEnabled.ValueBoolPointer(),
 	}
 
 	ok, err := r.client.DBaas.UpdateDBaasScheduleBackup(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.DbaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.DbaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 		input,
 	)
 	if !ok && err == nil {
@@ -241,10 +240,10 @@ func (r *dbaasBackupScheduleResource) Update(ctx context.Context, req resource.U
 	}
 
 	scheduleBackup, err := r.client.DBaas.GetDBaasScheduleBackup(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.DbaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.DbaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -270,10 +269,10 @@ func (r *dbaasBackupScheduleResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	scheduleBackup, err := r.client.DBaas.GetDBaasScheduleBackup(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.DbaasId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.DbaasId.ValueInt64(),
+		state.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -300,10 +299,10 @@ func (r *dbaasBackupScheduleResource) Delete(ctx context.Context, req resource.D
 
 	// DeleteDBaas API call logic
 	_, err := r.client.DBaas.DeleteDBaasScheduleBackup(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.DbaasId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.DbaasId.ValueInt64(),
+		state.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/dbaas/dbaas_data_source.go
+++ b/internal/services/dbaas/dbaas_data_source.go
@@ -153,9 +153,9 @@ func (d *dbaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	obj, err := d.client.DBaas.GetDBaaS(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -168,9 +168,9 @@ func (d *dbaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	data.fill(obj)
 
 	filteredIps, err := d.client.DBaas.GetIpFilters(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/dbaas/dbaas_packs_data_source.go
+++ b/internal/services/dbaas/dbaas_packs_data_source.go
@@ -51,13 +51,13 @@ type DBaasConstantsDataModel struct {
 }
 
 type DBaasPacksModel struct {
-	ID        types.Int32  `tfsdk:"id"`
+	ID        types.Int64  `tfsdk:"id"`
 	Type      types.String `tfsdk:"type"`
 	Group     types.String `tfsdk:"group"`
 	Name      types.String `tfsdk:"name"`
-	Instances types.Int32  `tfsdk:"instances"`
-	CPU       types.Int32  `tfsdk:"cpu"`
-	RAM       types.Int32  `tfsdk:"ram"`
+	Instances types.Int64  `tfsdk:"instances"`
+	CPU       types.Int64  `tfsdk:"cpu"`
+	RAM       types.Int64  `tfsdk:"ram"`
 	Storage   types.Int64  `tfsdk:"storage"`
 	Rates     RatesModel   `tfsdk:"rates"`
 }
@@ -94,7 +94,7 @@ func (d *dbaasPacksDataSource) Schema(ctx context.Context, _ datasource.SchemaRe
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
-						"id": schema.Int32Attribute{
+						"id": schema.Int64Attribute{
 							Computed: true,
 						},
 						"type": schema.StringAttribute{
@@ -106,13 +106,13 @@ func (d *dbaasPacksDataSource) Schema(ctx context.Context, _ datasource.SchemaRe
 						"name": schema.StringAttribute{
 							Computed: true,
 						},
-						"instances": schema.Int32Attribute{
+						"instances": schema.Int64Attribute{
 							Computed: true,
 						},
-						"cpu": schema.Int32Attribute{
+						"cpu": schema.Int64Attribute{
 							Computed: true,
 						},
-						"ram": schema.Int32Attribute{
+						"ram": schema.Int64Attribute{
 							Computed: true,
 						},
 						"storage": schema.Int64Attribute{
@@ -150,13 +150,13 @@ func (d *dbaasPacksDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	var tfPacks []DBaasPacksModel
 	for _, pack := range packs {
 		tfPacks = append(tfPacks, DBaasPacksModel{
-			ID:        types.Int32Value(pack.ID),
+			ID:        types.Int64Value(pack.ID),
 			Type:      types.StringValue(pack.Type),
 			Group:     types.StringValue(pack.Group),
 			Name:      types.StringValue(pack.Name),
-			Instances: types.Int32Value(pack.Instances),
-			CPU:       types.Int32Value(pack.CPU),
-			RAM:       types.Int32Value(pack.RAM),
+			Instances: types.Int64Value(pack.Instances),
+			CPU:       types.Int64Value(pack.CPU),
+			RAM:       types.Int64Value(pack.RAM),
 			Storage:   types.Int64Value(pack.Storage),
 			Rates: RatesModel{
 				CHF: PricingModel{

--- a/internal/services/dbaas/dbaas_resource.go
+++ b/internal/services/dbaas/dbaas_resource.go
@@ -186,8 +186,8 @@ func (r *dbaasResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	input := &dbaas.DBaaS{
 		Project: dbaas.DBaaSProject{
-			PublicCloudId: int(data.PublicCloudId.ValueInt64()),
-			ProjectId:     int(data.PublicCloudProjectId.ValueInt64()),
+			PublicCloudId: data.PublicCloudId.ValueInt64(),
+			ProjectId:     data.PublicCloudProjectId.ValueInt64(),
 		},
 		Region:  data.Region.ValueString(),
 		Version: data.Version.ValueString(),
@@ -206,7 +206,7 @@ func (r *dbaasResource) Create(ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	data.Id = types.Int64Value(int64(createInfos.Id))
+	data.Id = types.Int64Value(createInfos.Id)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	dbaasObject, err := r.waitUntilActive(ctx, input, createInfos.Id)
@@ -263,9 +263,9 @@ func (r *dbaasResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	// Read API call logic
 	dbaasObject, err := r.client.DBaas.GetDBaaS(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -276,9 +276,9 @@ func (r *dbaasResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	filteredIps, err := r.client.DBaas.GetIpFilters(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -318,10 +318,10 @@ func (r *dbaasResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	// Update API call logic
 	input := &dbaas.DBaaS{
 		Project: dbaas.DBaaSProject{
-			PublicCloudId: int(data.PublicCloudId.ValueInt64()),
-			ProjectId:     int(data.PublicCloudProjectId.ValueInt64()),
+			PublicCloudId: data.PublicCloudId.ValueInt64(),
+			ProjectId:     data.PublicCloudProjectId.ValueInt64(),
 		},
-		Id:      int(state.Id.ValueInt64()),
+		Id:      state.Id.ValueInt64(),
 		Name:    data.Name.ValueString(),
 		PackId:  chosenPackState.Id,
 		Region:  state.Region.ValueString(),
@@ -357,9 +357,9 @@ func (r *dbaasResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		IpFilters: cidrs,
 	}
 	ok, err := r.client.DBaas.PatchIpFilters(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.Id.ValueInt64(),
 		allowedCIDRs,
 	)
 	if !ok && err == nil {
@@ -395,9 +395,9 @@ func (r *dbaasResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	// DeleteDBaas API call logic
 	_, err := r.client.DBaas.DeleteDBaaS(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -455,7 +455,7 @@ func (r *dbaasResource) getPackId(data DBaasModel, diagnostic *diag.Diagnostics)
 }
 
 func (model *DBaasModel) fill(dbaas *dbaas.DBaaS) {
-	model.Id = types.Int64Value(int64(dbaas.Id))
+	model.Id = types.Int64Value(dbaas.Id)
 	model.KubernetesIdentifier = types.StringValue(dbaas.KubernetesIdentifier)
 	model.Region = types.StringValue(dbaas.Region)
 	model.Type = types.StringValue(dbaas.Type)
@@ -470,7 +470,7 @@ func (model *DBaasModel) fill(dbaas *dbaas.DBaaS) {
 	model.Ca = types.StringValue(dbaas.Connection.Ca)
 }
 
-func (r *dbaasResource) waitUntilActive(ctx context.Context, dbaas *dbaas.DBaaS, id int) (*dbaas.DBaaS, error) {
+func (r *dbaasResource) waitUntilActive(ctx context.Context, dbaas *dbaas.DBaaS, id int64) (*dbaas.DBaaS, error) {
 	t := time.NewTicker(5 * time.Second)
 	for {
 		select {

--- a/internal/services/dbaas/utils.go
+++ b/internal/services/dbaas/utils.go
@@ -10,9 +10,9 @@ import (
 )
 
 type ImportIds struct {
-	PublicCloudId        int
-	PublicCloudProjectId int
-	DbaasId              int
+	PublicCloudId        int64
+	PublicCloudProjectId int64
+	DbaasId              int64
 	Id                   string
 }
 
@@ -38,9 +38,9 @@ func parseBackupRestoreImport(req resource.ImportStateRequest) (*ImportIds, erro
 	}
 
 	return &ImportIds{
-		PublicCloudId:        int(publicCloudId),
-		PublicCloudProjectId: int(publicCloudProjectId),
-		DbaasId:              int(dbaasId),
+		PublicCloudId:        publicCloudId,
+		PublicCloudProjectId: publicCloudProjectId,
+		DbaasId:              dbaasId,
 		Id:                   id,
 	}, nil
 }

--- a/internal/services/kaas/kaas_data_source.go
+++ b/internal/services/kaas/kaas_data_source.go
@@ -178,9 +178,9 @@ func (d *kaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	obj, err := d.client.Kaas.GetKaas(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -191,9 +191,9 @@ func (d *kaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	kubeconfig, err := d.client.Kaas.GetKubeconfig(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -208,9 +208,9 @@ func (d *kaasDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	data.KubernetesVersion = types.StringValue(obj.KubernetesVersion)
 
 	apiserverParams, err := d.client.Kaas.GetApiserverParams(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/services/kaas/kaas_instance_pool_data_source.go
+++ b/internal/services/kaas/kaas_instance_pool_data_source.go
@@ -78,11 +78,11 @@ func (d *kaasInstancePoolDataSource) Schema(ctx context.Context, _ datasource.Sc
 				Computed:    true,
 				Description: "The flavor name of the instance in this instance pool",
 			},
-			"min_instances": schema.Int32Attribute{
+			"min_instances": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The minimum amount of instances in the instance pool",
 			},
-			"max_instances": schema.Int32Attribute{
+			"max_instances": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The maximum amount of instances in the instance pool",
 			},
@@ -103,10 +103,10 @@ func (d *kaasInstancePoolDataSource) Read(ctx context.Context, req datasource.Re
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	obj, err := d.client.Kaas.GetInstancePool(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.KaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.KaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -116,11 +116,11 @@ func (d *kaasInstancePoolDataSource) Read(ctx context.Context, req datasource.Re
 		return
 	}
 
-	data.Id = types.Int64Value(int64(obj.Id))
+	data.Id = types.Int64Value(obj.Id)
 	data.Name = types.StringValue(obj.Name)
 	data.FlavorName = types.StringValue(obj.FlavorName)
-	data.MinInstances = types.Int32Value(obj.MinInstances)
-	data.MaxInstances = types.Int32Value(obj.MaxInstances)
+	data.MinInstances = types.Int64Value(obj.MinInstances)
+	data.MaxInstances = types.Int64Value(obj.MaxInstances)
 	labels, diags := types.MapValueFrom(ctx, types.StringType, obj.Labels)
 	resp.Diagnostics.Append(diags...)
 	data.Labels = labels

--- a/internal/services/kaas/kaas_instance_pool_resource.go
+++ b/internal/services/kaas/kaas_instance_pool_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -45,8 +44,8 @@ type KaasInstancePoolModel struct {
 	Name             types.String `tfsdk:"name"`
 	AvailabilityZone types.String `tfsdk:"availability_zone"`
 	FlavorName       types.String `tfsdk:"flavor_name"`
-	MinInstances     types.Int32  `tfsdk:"min_instances"`
-	MaxInstances     types.Int32  `tfsdk:"max_instances"`
+	MinInstances     types.Int64  `tfsdk:"min_instances"`
+	MaxInstances     types.Int64  `tfsdk:"max_instances"`
 	Labels           types.Map    `tfsdk:"labels"`
 }
 
@@ -133,20 +132,20 @@ func (r *kaasInstancePoolResource) Schema(ctx context.Context, req resource.Sche
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"min_instances": schema.Int32Attribute{
+			"min_instances": schema.Int64Attribute{
 				Required:            true,
 				Description:         "The minimum amount of instances in this instance pool",
 				MarkdownDescription: "The minimum amount of instances in this instance pool",
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.UseStateForUnknown(),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"max_instances": schema.Int32Attribute{
+			"max_instances": schema.Int64Attribute{
 				Required:            true,
 				Description:         "The maximum amount of instances in this instance pool",
 				MarkdownDescription: "The maximum amount of instances in this instance pool",
-				PlanModifiers: []planmodifier.Int32{
-					int32planmodifier.UseStateForUnknown(),
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 				},
 			},
 			"labels": schema.MapAttribute{
@@ -175,19 +174,19 @@ func (r *kaasInstancePoolResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	input := &kaas.InstancePool{
-		KaasId:           int(data.KaasId.ValueInt64()),
+		KaasId:           data.KaasId.ValueInt64(),
 		Name:             data.Name.ValueString(),
 		AvailabilityZone: data.AvailabilityZone.ValueString(),
 		FlavorName:       data.FlavorName.ValueString(),
-		MinInstances:     data.MinInstances.ValueInt32(),
-		MaxInstances:     data.MaxInstances.ValueInt32(),
+		MinInstances:     data.MinInstances.ValueInt64(),
+		MaxInstances:     data.MaxInstances.ValueInt64(),
 		Labels:           r.getLabelsValues(data),
 	}
 
 	// CreateKaas API call logic
 	instancePoolId, err := r.client.Kaas.CreateInstancePool(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
 		input,
 	)
 	if err != nil {
@@ -198,7 +197,7 @@ func (r *kaasInstancePoolResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
-	data.Id = types.Int64Value(int64(instancePoolId))
+	data.Id = types.Int64Value(instancePoolId)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	isScalingDown := false
@@ -235,7 +234,7 @@ func (r *kaasInstancePoolResource) getLabelsValues(data KaasInstancePoolModel) m
 	return labels
 }
 
-func (r *kaasInstancePoolResource) waitUntilActive(ctx context.Context, data KaasInstancePoolModel, id int, scalingDown bool) (*kaas.InstancePool, error) {
+func (r *kaasInstancePoolResource) waitUntilActive(ctx context.Context, data KaasInstancePoolModel, id int64, scalingDown bool) (*kaas.InstancePool, error) {
 	scaleDownFailedQuotaCount := 0
 	scaleDownFailedQuotaAllowedRetrys := 5
 	ticker := time.NewTicker(5 * time.Second)
@@ -245,9 +244,9 @@ func (r *kaasInstancePoolResource) waitUntilActive(ctx context.Context, data Kaa
 			return nil, nil
 		case <-ticker.C:
 			found, err := r.client.Kaas.GetInstancePool(
-				int(data.PublicCloudId.ValueInt64()),
-				int(data.PublicCloudProjectId.ValueInt64()),
-				int(data.KaasId.ValueInt64()),
+				data.PublicCloudId.ValueInt64(),
+				data.PublicCloudProjectId.ValueInt64(),
+				data.KaasId.ValueInt64(),
 				id,
 			)
 			if err != nil {
@@ -265,7 +264,7 @@ func (r *kaasInstancePoolResource) waitUntilActive(ctx context.Context, data Kaa
 
 			// We need the instance pool to be active, have the same state as us, be scaled properly and be in bound of the autoscaling
 			isActive := found.Status == "Active"
-			isEquivalent := found.MinInstances == data.MinInstances.ValueInt32()
+			isEquivalent := found.MinInstances == data.MinInstances.ValueInt64()
 			isScaledProperly := found.AvailableInstances == found.TargetInstances
 			isInBound := found.MinInstances <= found.TargetInstances && found.TargetInstances <= found.MaxInstances
 			if isActive && isEquivalent && isScaledProperly && isInBound {
@@ -287,10 +286,10 @@ func (r *kaasInstancePoolResource) Read(ctx context.Context, req resource.ReadRe
 
 	// Read API call logic
 	obj, err := r.client.Kaas.GetInstancePool(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.KaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.KaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -327,19 +326,19 @@ func (r *kaasInstancePoolResource) Update(ctx context.Context, req resource.Upda
 
 	// Update API call logic
 	input := &kaas.InstancePool{
-		KaasId: int(data.KaasId.ValueInt64()),
-		Id:     int(state.Id.ValueInt64()),
+		KaasId: data.KaasId.ValueInt64(),
+		Id:     state.Id.ValueInt64(),
 
 		Name:         data.Name.ValueString(),
 		FlavorName:   data.FlavorName.ValueString(),
-		MinInstances: data.MinInstances.ValueInt32(),
-		MaxInstances: data.MaxInstances.ValueInt32(),
+		MinInstances: data.MinInstances.ValueInt64(),
+		MaxInstances: data.MaxInstances.ValueInt64(),
 		Labels:       r.getLabelsValues(data),
 	}
 
 	_, err := r.client.Kaas.UpdateInstancePool(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
 		input,
 	)
 	if err != nil {
@@ -350,8 +349,8 @@ func (r *kaasInstancePoolResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	scalingDown := data.MaxInstances.ValueInt32() < state.MaxInstances.ValueInt32()
-	instancePoolObject, err := r.waitUntilActive(ctx, data, int(state.Id.ValueInt64()), scalingDown)
+	scalingDown := data.MaxInstances.ValueInt64() < state.MaxInstances.ValueInt64()
+	instancePoolObject, err := r.waitUntilActive(ctx, data, state.Id.ValueInt64(), scalingDown)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error when waiting for KaaS Instance Pool to be Active",
@@ -382,10 +381,10 @@ func (r *kaasInstancePoolResource) Delete(ctx context.Context, req resource.Dele
 
 	// DeleteKaas API call logic
 	_, err := r.client.Kaas.DeleteInstancePool(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.KaasId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.KaasId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -433,10 +432,10 @@ func (r *kaasInstancePoolResource) ImportState(ctx context.Context, req resource
 }
 
 func (model *KaasInstancePoolModel) fill(instancePool *kaas.InstancePool) {
-	model.Id = types.Int64Value(int64(instancePool.Id))
+	model.Id = types.Int64Value(instancePool.Id)
 	model.Name = types.StringValue(instancePool.Name)
 	model.FlavorName = types.StringValue(instancePool.FlavorName)
-	model.MinInstances = types.Int32Value(instancePool.MinInstances)
-	model.MaxInstances = types.Int32Value(instancePool.MaxInstances)
+	model.MinInstances = types.Int64Value(instancePool.MinInstances)
+	model.MaxInstances = types.Int64Value(instancePool.MaxInstances)
 	model.AvailabilityZone = types.StringValue(instancePool.AvailabilityZone)
 }

--- a/internal/services/kaas/kaas_resource.go
+++ b/internal/services/kaas/kaas_resource.go
@@ -306,8 +306,8 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	input := &kaas.Kaas{
 		Project: kaas.KaasProject{
-			PublicCloudId: int(data.PublicCloudId.ValueInt64()),
-			ProjectId:     int(data.PublicCloudProjectId.ValueInt64()),
+			PublicCloudId: data.PublicCloudId.ValueInt64(),
+			ProjectId:     data.PublicCloudProjectId.ValueInt64(),
 		},
 		Region:            data.Region.ValueString(),
 		KubernetesVersion: data.KubernetesVersion.ValueString(),
@@ -325,7 +325,7 @@ func (r *kaasResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	data.Id = types.Int64Value(int64(kaasId))
+	data.Id = types.Int64Value(kaasId)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	kaasObject, err := r.waitUntilActive(ctx, input, kaasId)
@@ -418,7 +418,7 @@ func (state *KaasModel) canSetApiserverToNil() bool {
 	return apiserver.Audit == nil && apiserver.Oidc == nil && apiserver.Params.IsNull()
 }
 
-func (r *kaasResource) waitUntilActive(ctx context.Context, kaas *kaas.Kaas, id int) (*kaas.Kaas, error) {
+func (r *kaasResource) waitUntilActive(ctx context.Context, kaas *kaas.Kaas, id int64) (*kaas.Kaas, error) {
 	for {
 		found, err := r.client.Kaas.GetKaas(kaas.Project.PublicCloudId, kaas.Project.ProjectId, id)
 		if err != nil {
@@ -462,9 +462,9 @@ func (r *kaasResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	// Read API call logic
 	kaasObject, err := r.client.Kaas.GetKaas(
-		int(state.PublicCloudId.ValueInt64()),
-		int(state.PublicCloudProjectId.ValueInt64()),
-		int(state.Id.ValueInt64()),
+		state.PublicCloudId.ValueInt64(),
+		state.PublicCloudProjectId.ValueInt64(),
+		state.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -481,7 +481,7 @@ func (r *kaasResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		resp.Diagnostics.AddWarning("could not fetch and set kubeconfig", err.Error())
 	}
 
-	apiserverParams, err := r.client.Kaas.GetApiserverParams(int(state.PublicCloudId.ValueInt64()), int(state.PublicCloudProjectId.ValueInt64()), kaasObject.Id)
+	apiserverParams, err := r.client.Kaas.GetApiserverParams(state.PublicCloudId.ValueInt64(), state.PublicCloudProjectId.ValueInt64(), kaasObject.Id)
 	if err != nil {
 		resp.Diagnostics.AddWarning(
 			"Could not get Oidc",
@@ -540,13 +540,13 @@ func (r *kaasResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *kaasResource) prepareUpdateInput(state, data KaasModel, packID int) *kaas.Kaas {
+func (r *kaasResource) prepareUpdateInput(state, data KaasModel, packID int64) *kaas.Kaas {
 	input := &kaas.Kaas{
 		Project: kaas.KaasProject{
-			PublicCloudId: int(data.PublicCloudId.ValueInt64()),
-			ProjectId:     int(data.PublicCloudProjectId.ValueInt64()),
+			PublicCloudId: data.PublicCloudId.ValueInt64(),
+			ProjectId:     data.PublicCloudProjectId.ValueInt64(),
 		},
-		Id:                int(state.Id.ValueInt64()),
+		Id:                state.Id.ValueInt64(),
 		Name:              data.Name.ValueString(),
 		PackId:            packID,
 		Region:            state.Region.ValueString(),
@@ -619,9 +619,9 @@ func (r *kaasResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	// DeleteKaas API call logic
 	_, err := r.client.Kaas.DeleteKaas(
-		int(data.PublicCloudId.ValueInt64()),
-		int(data.PublicCloudProjectId.ValueInt64()),
-		int(data.Id.ValueInt64()),
+		data.PublicCloudId.ValueInt64(),
+		data.PublicCloudProjectId.ValueInt64(),
+		data.Id.ValueInt64(),
 	)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -700,7 +700,7 @@ func (r *kaasResource) getPackId(data KaasModel, diagnostic *diag.Diagnostics) (
 }
 
 func (model *KaasModel) fill(kaas *kaas.Kaas) {
-	model.Id = types.Int64Value(int64(kaas.Id))
+	model.Id = types.Int64Value(kaas.Id)
 	model.Region = types.StringValue(kaas.Region)
 	model.KubernetesVersion = types.StringValue(kaas.KubernetesVersion)
 	model.Name = types.StringValue(kaas.Name)

--- a/internal/services/kaas/kaas_resource_test.go
+++ b/internal/services/kaas/kaas_resource_test.go
@@ -137,7 +137,7 @@ func TestKaasResource_Plan(t *testing.T) {
 }
 
 func TestKaasResource_Import(t *testing.T) {
-	var resourcePublicCloudId, resourcePublicCloudProjectId, resourceId int
+	var resourcePublicCloudId, resourcePublicCloudProjectId, resourceId int64
 
 	client := mockKaas.New()
 	kaasId, err := client.CreateKaas(&kaas.Kaas{


### PR DESCRIPTION
This pull request refactor the entire codebase where we used something else than int64 to represent an integer. It allows us to remove every unused casts and to have the same type everywhere.

Depends-On: https://github.com/Infomaniak/terraform-provider-infomaniak/pull/58