### PR TITLE
fix(ci): failure on main branch

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -60,6 +60,7 @@ jobs:
       run:  echo 'Artifact URL is ${{ steps.artifact-upload-step.outputs.artifact-url }}'
 
     - name: Cobertura pull request comment unit test
+      if: github.event_name == 'pull_request'
       uses: 5monkeys/cobertura-action@ee5787cc56634acddedc51f21c7947985531e6eb
       with:
         report_name: Pure Unit test coverage
@@ -68,6 +69,7 @@ jobs:
         minimum_coverage: 0
 
     - name: Cobertura pull request comment global coverage
+      if: github.event_name == 'pull_request'
       uses: 5monkeys/cobertura-action@ee5787cc56634acddedc51f21c7947985531e6eb
       with:
         report_name: Global test coverage
@@ -76,6 +78,7 @@ jobs:
         minimum_coverage: 10
 
     - name: Comment PR
+      if: github.event_name == 'pull_request'
       uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b
       with:
         message: |


### PR DESCRIPTION
CI fail on `main` because some steps of the test ci where only made for pull requests.
This PR allows to skip pull requests specific tests.