### PR TITLE
fix(dbaas): fix nil pointer when connection information are not filled yet

### DIFF
--- a/internal/services/dbaas/dbaas_resource.go
+++ b/internal/services/dbaas/dbaas_resource.go
@@ -372,11 +372,13 @@ func (model *DBaasModel) fill(dbaas *dbaas.DBaaS) {
 	model.Name = types.StringValue(dbaas.Name)
 	model.PackName = types.StringValue(dbaas.Pack.Name)
 
-	model.Host = types.StringValue(dbaas.Connection.Host)
-	model.Port = types.StringValue(dbaas.Connection.Port)
-	model.User = types.StringValue(dbaas.Connection.User)
-	model.Password = types.StringValue(dbaas.Connection.Password)
-	model.Ca = types.StringValue(dbaas.Connection.Ca)
+	if dbaas.Connection != nil {
+		model.Host = types.StringValue(dbaas.Connection.Host)
+		model.Port = types.StringValue(dbaas.Connection.Port)
+		model.User = types.StringValue(dbaas.Connection.User)
+		model.Password = types.StringValue(dbaas.Connection.Password)
+		model.Ca = types.StringValue(dbaas.Connection.Ca)
+	}
 }
 
 func (r *dbaasResource) waitUntilActive(ctx context.Context, dbaas *dbaas.DBaaS, id int64) (*dbaas.DBaaS, error) {


### PR DESCRIPTION
This pull request makes a small but important change to the `fill` method in `dbaas_resource.go`. The change ensures that connection-related fields are only set if the `Connection` object is not `nil`, preventing potential nil pointer errors.

* Only populate the `Host`, `Port`, `User`, `Password`, and `Ca` fields in the model if `dbaas.Connection` is not `nil`, improving code safety.