### PR TITLE
fix(dbaas): fix password output on first create

### DIFF
--- a/internal/apis/dbaas/models.go
+++ b/internal/apis/dbaas/models.go
@@ -104,7 +104,7 @@ type DBaasBackupSchedule struct {
 
 type DBaaSCreateInfo struct {
 	Id             int64  `json:"id"`
-	RootPassword   string `json:"root_password"`
+	RootPassword   string `json:"admin_password"`
 	KubeIdentifier string `json:"kube_identifier"`
 }
 

--- a/internal/services/dbaas/dbaas_resource.go
+++ b/internal/services/dbaas/dbaas_resource.go
@@ -158,6 +158,7 @@ func (r *dbaasResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	data.fill(dbaasObject)
+	data.Password = types.StringValue(createInfos.RootPassword)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
This pull request introduces a small but important change to the `Create` method in `dbaas_resource.go`. The change ensures that the root password returned from the database creation process is now correctly set in the resource data, allowing it to be stored in the Terraform state.

* Set the `Password` field in the resource data to the root password returned by the database creation process in the `Create` method of `dbaas_resource.go`.