### PR TITLE
docs(dbaas): available engine params

### DIFF
--- a/docs/resources/dbaas.md
+++ b/docs/resources/dbaas.md
@@ -78,7 +78,7 @@ resource "infomaniak_dbaas" "db-0" {
 - `version` (String) The version of the database to use.
 - `name` (String) The name of the DBaaS shown on the manager.
 - `allowed_cidrs` (List of String) The list of allowed cidrs to access to the database.
-- `configuration` (Map String => String) Key Value Map for specific engine params.
+- `configuration` (Map String => String) Key Value Map for specific engine params. For available params, please refer to [this documentation](https://developer.infomaniak.com/docs/api/put/1/public_clouds/%7Bpublic_cloud_id%7D/projects/%7Bpublic_cloud_project_id%7D/dbaas/%7Bdbaas_id%7D/configurations).
 
 ### Read-Only
 


### PR DESCRIPTION
This pull request updates the documentation for the `infomaniak_dbaas` resource to provide clearer guidance on configuring engine parameters. The most important change is an improvement to the description of the `configuration` property, now including a link to the official documentation for available parameters.

Documentation improvements:

* Updated the `configuration` property description in `docs/resources/dbaas.md` to include a reference link to the Infomaniak API documentation for available engine parameters.