### PR TITLE
fix(dbaas): disable unknown type unmarshaling in configuration

### DIFF
--- a/internal/apis/dbaas/models.go
+++ b/internal/apis/dbaas/models.go
@@ -3,6 +3,7 @@ package dbaas
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -61,8 +62,10 @@ func (sm *StringMap) UnmarshalJSON(data []byte) error {
 		switch v := value.(type) {
 		case string:
 			(*sm)[key] = v
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			(*sm)[key] = fmt.Sprint(v)
 		default:
-			(*sm)[key] = fmt.Sprintf("%v", v)
+			return fmt.Errorf("unsupported type for key %v: (%v) %v", key, reflect.TypeOf(v), v)
 		}
 	}
 	return nil


### PR DESCRIPTION
This pull request improves the robustness of the `StringMap` JSON unmarshalling logic in the `dbaas` package. The changes ensure that only supported types are handled and that unsupported types are clearly reported as errors.

Improvements to type handling in JSON unmarshalling:

* Updated the `UnmarshalJSON` method in `internal/apis/dbaas/models.go` to explicitly handle all common numeric types by converting them to strings using `fmt.Sprint`. This avoids ambiguity and ensures consistent behavior for numeric values.
* Added error reporting for unsupported types in the `UnmarshalJSON` method, returning a detailed error message that includes the key, type, and value when an unexpected type is encountered.
* Imported the `reflect` package to provide type information for error messages in the `UnmarshalJSON` method.