### PR TITLE
fix(domain): add stricter validation to prevent users from adding empty sources

### DIFF
--- a/internal/services/domain/record_resource_schema.go
+++ b/internal/services/domain/record_resource_schema.go
@@ -27,6 +27,9 @@ func getRecordResourceSchema() schema.Schema {
 			"source": schema.StringAttribute{
 				Required:            true,
 				MarkdownDescription: "The source of the Record.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
Empty sources are weird on our API, they register but once we GET them, they read as "." instead of "".

We could do a patch on our side, but it doesn't reflect what the majority of API consumers will expect.

An improvement is to be made and is scheduled for when the v3 of the API, in the meantime we can prevent the users here from using empty sources as this result in an incoherent state.

Putting "." instead of "" has the same behavior however and still allows users to register records on the Apex domain.

Closes #89 